### PR TITLE
Handle nested symbol $in and $nin during Selector.merge! correctly

### DIFF
--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -22,7 +22,7 @@ module Mongoid
         def merge!(other)
           other.each_pair do |key, value|
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
-              value = self[key.to_s].merge(value.transform_keys(&:to_s)) do |_key, old_val, new_val|
+              value = self[key.to_s].transform_keys(&:to_s).merge(value.transform_keys(&:to_s)) do |_key, old_val, new_val|
                 case _key
                 when '$in'
                   new_val & old_val

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -22,7 +22,7 @@ module Mongoid
         def merge!(other)
           other.each_pair do |key, value|
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
-              value = self[key.to_s].merge(value) do |_key, old_val, new_val|
+              value = self[key.to_s].merge(value.transform_keys(&:to_s)) do |_key, old_val, new_val|
                 case _key
                 when '$in'
                   new_val & old_val

--- a/spec/mongoid/criteria/queryable/selector_spec.rb
+++ b/spec/mongoid/criteria/queryable/selector_spec.rb
@@ -100,6 +100,23 @@ describe Mongoid::Criteria::Queryable::Selector do
         end
       end
 
+      context "when merging in a symbol $in with an intersecting value" do
+
+        let(:other) do
+          { "field" => { :$in => [1] } }
+        end
+
+        before do
+          selector.merge!(other)
+        end
+
+        it "intersects the $in values" do
+          expect(selector).to eq({
+                                     "field" => { "$in" => [1] }
+                                 })
+        end
+      end
+
       context "when merging in a new $in with no intersecting values" do
 
         let(:other) do

--- a/spec/mongoid/criteria/queryable/selector_spec.rb
+++ b/spec/mongoid/criteria/queryable/selector_spec.rb
@@ -71,6 +71,28 @@ describe Mongoid::Criteria::Queryable::Selector do
           })
         end
       end
+
+      context "when merging in a new symbol $nin" do
+
+        let(:other) do
+          { "field" => { "$nin" => ["bar"] } }
+        end
+
+        before do
+          selector["field"] = { :$nin => ["foo"] }
+          selector.merge!(other)
+        end
+
+        it "combines the two $nin queries into one" do
+          expect(selector).to eq({
+            "field" => { "$nin" => ["foo", "bar"] }
+          })
+        end
+
+        after do
+          selector["field"] = initial
+        end
+      end
     end
 
     context "when selector contains a $in" do
@@ -103,10 +125,11 @@ describe Mongoid::Criteria::Queryable::Selector do
       context "when merging in a symbol $in with an intersecting value" do
 
         let(:other) do
-          { "field" => { :$in => [1] } }
+          { "field" => { "$in" => [1] } }
         end
 
         before do
+          selector["field"] = { :$in => [1] }
           selector.merge!(other)
         end
 
@@ -114,6 +137,10 @@ describe Mongoid::Criteria::Queryable::Selector do
           expect(selector).to eq({
                                      "field" => { "$in" => [1] }
                                  })
+        end
+
+        after do
+          selector["field"] = initial
         end
       end
 


### PR DESCRIPTION
#### Summary

This change was originally inspired by a symbol-string bug manifesting in a chained `Query.where().where()`. A key component of this bug is was in `Selector.merge!()`. While creating a test to specifically repro the bug with `Selector.merge!()`, I realized that `Selector.merge!()` was more flawed than an original simple fix of `case _key` => `case _key.to_s`.

This PR is serving as a draft PR before I submit the PR to `Mongoid:master`. Let me know if this has the go-ahead.

#### Original Repro

`query.where(:f => { :$in => [...] }).where(:f => { "$in" => [...] })`

#### Notes

* As for the remaining code change mentioned in the Query.where().where(), that code change has to do with a different module (Storable vs. Selector). I feel like it would make more sense to submit that change as a separate PR.

#### Test Output (No Changes)

```
% rake spec

  1) Mongoid::Criteria::Queryable::Selector merge! when selector contains a $nin when merging in a new symbol $nin combines the two $nin queries into one
     Failure/Error:
       expect(selector).to eq({
         "field" => { "$nin" => ["foo", "bar"] }
       })
     
       expected: {"field"=>{"$nin"=>["foo", "bar"]}}
            got: {"field"=>{:$nin=>["foo"], "$nin"=>["bar"]}}
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -"field" => {"$nin"=>["foo", "bar"]},
       +"field" => {:$nin=>["foo"], "$nin"=>["bar"]},
                                                                                                                                                                  
  2) Mongoid::Criteria::Queryable::Selector merge! when selector contains a $in when merging in a symbol $in with an intersecting value intersects the $in values
     Failure/Error:
       expect(selector).to eq({
                                  "field" => { "$in" => [1] }
                              })
     
       expected: {"field"=>{"$in"=>[1]}}
            got: {"field"=>{:$in=>[1], "$in"=>[1]}}
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -"field" => {"$in"=>[1]},
       +"field" => {:$in=>[1], "$in"=>[1]},

XYZ examples, 2 failures
```

#### Test Output (Fix Implemented)

```
% rake spec

XYZ examples, 0 failures
```