### PR TITLE
Storable fix when adding a String equivalent of an existing Symbol op…

### DIFF
--- a/lib/mongoid/criteria/queryable/storable.rb
+++ b/lib/mongoid/criteria/queryable/storable.rb
@@ -48,7 +48,7 @@ module Mongoid
             if value.is_a?(Hash) && selector[field].is_a?(Hash) &&
               value.keys.all? { |key|
                 key_s = key.to_s
-                key_s[0] == ?$ && !selector[field].key?(key_s)
+                key_s[0] == ?$ && !selector[field].transform_keys(&:to_s).key?(key_s)
               }
             then
               # Multiple operators can be combined on the same field by

--- a/spec/mongoid/criteria/queryable/storable_spec.rb
+++ b/spec/mongoid/criteria/queryable/storable_spec.rb
@@ -129,6 +129,28 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
     end
 
+    context 'when a String equivalent of an existing Symbol operator is added' do
+      let(:modified) do
+        query.add_field_expression('foo', {:$in=>[1,2]})
+        query.add_field_expression('foo', {"$in"=>[2,3]})
+      end
+
+      it 'connects the equivalent operators with $and' do
+        modified.selector.should == {
+          '$and' => [
+            {
+              "foo"=> {
+                "$in"=>[2, 3]
+              }
+            }
+          ],
+          "foo"=> {
+            :$in=> [1, 2]
+          }
+        }
+      end
+    end
+
     context 'an operator write' do
       let(:modified) do
         query.add_field_expression('$eq', {'foo' => 'bar'})


### PR DESCRIPTION
…erator via add_field_expression()

#### Summary

This is the second piece of a symbol-string bug manifesting in a chained `Query.where().where()`. The second component of this bug was in `Storable.add_field_expression()`. This change includes both the fix and a test reproducing the bug in the old code.

This PR is serving as a draft PR before I submit the PR to Mongoid:master. Let me know if this has the go-ahead.

#### Original Repro
`query.where(:f => { :$in => [...] }).where(:f => { "$in" => [...] })`

#### Test Output (No Changes)

```
% rake spec

  1) Mongoid::Criteria::Queryable::Storable#add_field_expression when a String equivalent of an existing Symbol operator is added connects the equivalent operators with $and
     Failure/Error:
       modified.selector.should == {
         '$and' => [
           {
             "foo"=> {
               "$in"=>[2, 3]
             }
           }
         ],
         "foo"=> {
           :$in=> [1, 2]
     
       expected: {"$and"=>[{"foo"=>{"$in"=>[2, 3]}}], "foo"=>{:$in=>[1, 2]}}
            got: {"foo"=>{:$in=>[1, 2], "$in"=>[2, 3]}} (using ==)
       Diff:
       @@ -1,3 +1,2 @@
       -"$and" => [{"foo"=>{"$in"=>[2, 3]}}],
       -"foo" => {:$in=>[1, 2]},
       +"foo" => {:$in=>[1, 2], "$in"=>[2, 3]},

XYZ examples, 1 failure
```

#### Test Output (Fix Implemented)

```
% rake spec

XYZ examples, 0 failures
```