### PR TITLE
Fix extract_attribute() behavior for numeric hash key inside expanded array

### DIFF
--- a/spec/mongoid/matcher/extract_attribute_data/traversal.yml
+++ b/spec/mongoid/matcher/extract_attribute_data/traversal.yml
@@ -257,3 +257,34 @@
   exists: false
   value: ~
   expanded: false
+
+- name: numeric Hash key inside expanded array
+  document: &numeric-hash-keys-in-expanded-array
+    a:
+      '1':
+        b:
+          -
+            c:
+              '2': 3
+          -
+            d:
+              '4': 5
+          - e: f
+          -
+            d:
+              '4': 6
+
+  key: a.1.b.c.2
+
+  exists: true
+  value: [3]
+  expanded: true
+
+- name: multiple numeric Hash keys inside expanded array
+  document: *numeric-hash-keys-in-expanded-array
+
+  key: a.1.b.d.4
+
+  exists: true
+  value: [5,6]
+  expanded: true


### PR DESCRIPTION
#### Summary

`Mongoid::Matcher.expand_attribute()` did not correctly handles numeric hash keys inside expanded arrays. This PR provides the fix + test cases.

#### Test Output (No Changes)

```
% rake spec

  1) Matcher.extract_attribute traversal.yml numeric Hash key inside expanded array has the expected exists flag
     Failure/Error: actual[0].should == expected_exists
     
       expected: true
            got: false (using ==)
       Diff:
       @@ -1 +1 @@
       -true
       +false
                                                                                                                        
  2) Matcher.extract_attribute traversal.yml numeric Hash key inside expanded array has the expected value
     Failure/Error: actual[1].should == expected_value

       expected: [3]
            got: nil (using ==)
                                                                                                                                             
  3) Matcher.extract_attribute traversal.yml multiple numeric Hash keys inside expanded array has the expected exists flag
     Failure/Error: actual[0].should == expected_exists

       expected: true
            got: false (using ==)
       Diff:
       @@ -1 +1 @@
       -true
       +false
                                                                                                                                                 
  4) Matcher.extract_attribute traversal.yml multiple numeric Hash keys inside expanded array has the expected value
     Failure/Error: actual[1].should == expected_value
     
       expected: [5, 6]
            got: nil (using ==)

XYZ examples, 4 failures
```

#### Test Output (Fix Implemented)

```
XYZ examples, 0 failures
```